### PR TITLE
feat: add typesafe webhook event handlers

### DIFF
--- a/example/convex/http.ts
+++ b/example/convex/http.ts
@@ -6,26 +6,25 @@ const http = httpRouter();
 polar.registerRoutes(http, {
   // Optional custom path, default is "/polar/events"
   path: "/polar/events",
-  // Optional callback for when a subscription is updated
-  onSubscriptionUpdated: async (ctx, event) => {
-    console.log("Subscription updated", event);
-    if (event.data.customerCancellationReason) {
-      console.log(
-        "Customer cancellation reason",
-        event.data.customerCancellationReason
-      );
-      console.log(
-        "Customer cancellation comment",
-        event.data.customerCancellationComment
-      );
-    }
-    // This callback is run in an Action, so you could pipe this customer
-    // cancellation reason to another service, for example.
+  // Typesafe event handlers for any Polar webhook event.
+  events: {
+    "subscription.updated": async (ctx, event) => {
+      console.log("Subscription updated", event);
+      if (event.data.customerCancellationReason) {
+        console.log(
+          "Customer cancellation reason",
+          event.data.customerCancellationReason
+        );
+        console.log(
+          "Customer cancellation comment",
+          event.data.customerCancellationComment
+        );
+      }
+    },
+    "order.created": async (ctx, event) => {
+      console.log("Order created", event.data.id);
+    },
   },
-  // Other available callbacks:
-  onSubscriptionCreated: undefined,
-  onProductCreated: undefined,
-  onProductUpdated: undefined,
 });
 
 export default http;


### PR DESCRIPTION
## Summary

- Add `events` option to `registerRoutes` with typesafe handlers for any Polar webhook event
- Full TypeScript inference on event payloads via discriminated union from the Polar SDK
- Deprecate individual `onSubscriptionCreated`/`onSubscriptionUpdated`/`onProductCreated`/`onProductUpdated` callbacks (still work, merged internally)
- Built-in handling (persisting subscriptions and products) always runs automatically

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (47 tests)
- [x] Example app compiles with new `events` API
- [ ] Manual test with Polar sandbox webhook events

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Webhook event handling simplified through a unified `events` map configuration, consolidating support for 30+ Polar webhook event types with full TypeScript type inference and automatic built-in persistence.

* **Documentation**
  * Updated integration examples and API documentation reflecting the new events-based webhook handler configuration and complete list of supported event types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->