### PR TITLE
feat: Add returnUrl parameter to Customer Portal session

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -187,7 +187,7 @@ export class Polar<
   }
   async createCustomerPortalSession(
     ctx: GenericActionCtx<DataModel>,
-    { userId }: { userId: string },
+    { userId, returnUrl }: { userId: string, returnUrl?: string | undefined },
   ) {
     const customer = await ctx.runQuery(
       this.component.lib.getCustomerByUserId,
@@ -200,6 +200,7 @@ export class Polar<
 
     const session = await customerSessionsCreate(this.polar, {
       customerId: customer.id,
+      returnUrl,
     });
     if (!session.ok) {
       throw session.error;
@@ -392,12 +393,15 @@ export class Polar<
         },
       }),
       generateCustomerPortalUrl: actionGeneric({
-        args: {},
+        args: {
+          returnUrl: v.optional(v.string())
+        },
         returns: v.object({ url: v.string() }),
-        handler: async (ctx) => {
+        handler: async (ctx, args) => {
           const { userId } = await this.config.getUserInfo(ctx);
           const { url } = await this.createCustomerPortalSession(ctx, {
             userId,
+            returnUrl: args.returnUrl
           });
           return { url };
         },

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -187,7 +187,7 @@ export class Polar<
   }
   async createCustomerPortalSession(
     ctx: GenericActionCtx<DataModel>,
-    { userId, returnUrl }: { userId: string, returnUrl?: string | undefined },
+    { userId, returnUrl }: { userId: string; returnUrl?: string },
   ) {
     const customer = await ctx.runQuery(
       this.component.lib.getCustomerByUserId,

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -1,10 +1,5 @@
 import { PolarEmbedCheckout } from "@polar-sh/checkout/embed";
-import {
-  useEffect,
-  useState,
-  type PropsWithChildren,
-  type MouseEvent,
-} from "react";
+import { useEffect, useState, type PropsWithChildren, type MouseEvent } from "react";
 import { useAction } from "convex/react";
 import type { PolarComponentApi } from "../client/index.js";
 export const CustomerPortalLink = ({
@@ -23,9 +18,7 @@ export const CustomerPortalLink = ({
   const [portalUrl, setPortalUrl] = useState<string>();
 
   useEffect(() => {
-    void generateCustomerPortalUrl({
-      returnUrl: returnUrl ?? window.location.href,
-    }).then((result) => {
+    void generateCustomerPortalUrl({ returnUrl }).then((result) => {
       if (result) {
         setPortalUrl(result.url);
       }
@@ -89,17 +82,7 @@ export const CheckoutLink = ({
       trialIntervalCount,
       locale,
     }).then(({ url }) => setCheckoutLink(url));
-  }, [
-    lazy,
-    productIds,
-    subscriptionId,
-    metadata,
-    embed,
-    generateCheckoutLink,
-    trialInterval,
-    trialIntervalCount,
-    locale,
-  ]);
+  }, [lazy, productIds, subscriptionId, metadata, embed, generateCheckoutLink, trialInterval, trialIntervalCount, locale]);
 
   const handleClick = lazy
     ? async (e: MouseEvent) => {

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -1,14 +1,21 @@
 import { PolarEmbedCheckout } from "@polar-sh/checkout/embed";
-import { useEffect, useState, type PropsWithChildren, type MouseEvent } from "react";
+import {
+  useEffect,
+  useState,
+  type PropsWithChildren,
+  type MouseEvent,
+} from "react";
 import { useAction } from "convex/react";
 import type { PolarComponentApi } from "../client/index.js";
 export const CustomerPortalLink = ({
   polarApi,
   children,
   className,
+  returnUrl,
 }: PropsWithChildren<{
   polarApi: Pick<PolarComponentApi, "generateCustomerPortalUrl">;
   className?: string;
+  returnUrl?: string;
 }>) => {
   const generateCustomerPortalUrl = useAction(
     polarApi.generateCustomerPortalUrl,
@@ -16,12 +23,14 @@ export const CustomerPortalLink = ({
   const [portalUrl, setPortalUrl] = useState<string>();
 
   useEffect(() => {
-    void generateCustomerPortalUrl({}).then((result) => {
+    void generateCustomerPortalUrl({
+      returnUrl: returnUrl ?? window.location.href,
+    }).then((result) => {
       if (result) {
         setPortalUrl(result.url);
       }
     });
-  }, [generateCustomerPortalUrl]);
+  }, [generateCustomerPortalUrl, returnUrl]);
 
   if (!portalUrl) {
     return null;
@@ -80,7 +89,17 @@ export const CheckoutLink = ({
       trialIntervalCount,
       locale,
     }).then(({ url }) => setCheckoutLink(url));
-  }, [lazy, productIds, subscriptionId, metadata, embed, generateCheckoutLink, trialInterval, trialIntervalCount, locale]);
+  }, [
+    lazy,
+    productIds,
+    subscriptionId,
+    metadata,
+    embed,
+    generateCheckoutLink,
+    trialInterval,
+    trialIntervalCount,
+    locale,
+  ]);
 
   const handleClick = lazy
     ? async (e: MouseEvent) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "allowJs": true,
     "checkJs": true,
     "strict": true,
+
     "target": "ESNext",
     "lib": ["ES2021", "dom", "DOM.Iterable"],
     "jsx": "react-jsx",
@@ -13,6 +14,7 @@
     // But when building we use Bundler & ESNext for ESM
     "module": "Node16",
     "moduleResolution": "NodeNext",
+
     "composite": true,
     "isolatedModules": true,
     "declaration": true,
@@ -21,8 +23,7 @@
     "rootDir": "./src",
     "outDir": "./dist",
     "verbatimModuleSyntax": true,
-    "skipLibCheck": true,
-    "types": ["node"]
+    "skipLibCheck": true
   },
   "include": ["./src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "allowJs": true,
     "checkJs": true,
     "strict": true,
-
     "target": "ESNext",
     "lib": ["ES2021", "dom", "DOM.Iterable"],
     "jsx": "react-jsx",
@@ -14,7 +13,6 @@
     // But when building we use Bundler & ESNext for ESM
     "module": "Node16",
     "moduleResolution": "NodeNext",
-
     "composite": true,
     "isolatedModules": true,
     "declaration": true,
@@ -23,7 +21,8 @@
     "rootDir": "./src",
     "outDir": "./dist",
     "verbatimModuleSyntax": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
## Summary                                                                                                          
                                                    
  - Adds an optional returnUrl parameter to createCustomerPortalSession and the generateCustomerPortalUrl action,  
  allowing callers to specify where Polar should redirect the customer after they leave the portal.
  - Updates the CustomerPortalLink React component to accept a returnUrl prop, defaulting to `window.location.href`  
  so users are returned to the page they came from.                                                                
  
 ## Changes                                                                                                          
                                                    
  - src/client/index.ts — Accept and forward returnUrl in `createCustomerPortalSession` and the                      
  `generateCustomerPortalUrl` action handler.
  - src/react/index.tsx — Add `returnUrl` prop to `CustomerPortalLink`, default to current page URL.
  - tsconfig.json — Add "types": ["node"] so VS Code doesn't complain about `process.env`.
----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.